### PR TITLE
Add a "Show in Finder" button to system snippets row.

### DIFF
--- a/ACCodeSnippetRepository/Controllers/ACCodeSnippetRepositoryConfigurationWindowController.m
+++ b/ACCodeSnippetRepository/Controllers/ACCodeSnippetRepositoryConfigurationWindowController.m
@@ -241,6 +241,9 @@ NSString * const ACCodeSnippetRepositoryUpdateRegularlyKey = @"ACCodeSnippetRepo
     }
 }
 
+- (IBAction)openSystemSnippetsDirectoryAction:(id)sender {
+    [[NSWorkspace sharedWorkspace] selectFile:[self systemSnippetsPath] inFileViewerRootedAtPath:nil];
+}
 
 - (NSString*)systemSnippetsPath {
     NSBundle *bundle = [NSBundle bundleForClass:NSClassFromString(@"IDECodeSnippetRepository")];

--- a/ACCodeSnippetRepository/Controllers/ACCodeSnippetRepositoryConfigurationWindowController.xib
+++ b/ACCodeSnippetRepository/Controllers/ACCodeSnippetRepositoryConfigurationWindowController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13C64" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5056"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ACCodeSnippetRepositoryConfigurationWindowController">
@@ -17,10 +17,10 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application"/>
-        <window title="Snippets Repository Configuration" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" wantsToBeColor="NO" animationBehavior="default" id="1">
+        <window title="Snippets Repository Configuration" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="596" y="535" width="527" height="235"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="527" height="235"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -109,6 +109,17 @@ https://github.com/acoomans/ACCodeSnippetRepositoryPlugin</string>
                         </buttonCell>
                         <connections>
                             <action selector="restoreSystemSnippets:" target="-2" id="QYf-rg-aUR"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ywk-cq-vim">
+                        <rect key="frame" x="328" y="110" width="133" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Show in Finder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gMX-IB-WsW">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="openSystemSnippetsDirectoryAction:" target="-2" id="1Se-I7-wM6"/>
                         </connections>
                     </button>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="vnv-22-gD2">
@@ -223,7 +234,7 @@ https://github.com/acoomans/ACCodeSnippetRepositoryPlugin</string>
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="167" y="107" width="369" height="57"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" id="5cI-54-i0V">
                 <rect key="frame" x="0.0" y="0.0" width="369" height="57"/>
                 <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
Users who need to correct permissions with the system snippets encounter an unhelpful error message — users may not know where the system snippets are kept:

![screen shot 2014-05-25 at 2 58 06 pm](https://cloud.githubusercontent.com/assets/34314/3077764/e7086cca-e441-11e3-9598-3f75020e5082.png)

In this pull request, I added a button to reveal the location of the system snippets so the user can change permission in the Finder.

![screen shot 2014-05-25 at 3 22 51 pm](https://cloud.githubusercontent.com/assets/34314/3077766/fd3f8320-e441-11e3-9338-66d832346d47.png)

---

I also have an alternate, or complementary approach on a separate branch (not included in this PR) that shows the full path in the error message. The change is helpful, but maybe inelegant. I'd be happy to include those changes in this PR, or make a separate PR. 

https://github.com/fcanas/ACCodeSnippetRepositoryPlugin/compare/informative-permission-error

![screen shot 2014-05-25 at 2 58 59 pm](https://cloud.githubusercontent.com/assets/34314/3077772/6e163ada-e442-11e3-8c4c-61316f355d99.png)
