### PR TITLE
support Xcode 6.3.1

### DIFF
--- a/ACCodeSnippetRepository.xcodeproj/project.xcworkspace/xcshareddata/ACCodeSnippetRepository.xccheckout
+++ b/ACCodeSnippetRepository.xcodeproj/project.xcworkspace/xcshareddata/ACCodeSnippetRepository.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>471B334B-B933-46EB-98D1-95A9EACDF82F</string>
+	<key>IDESourceControlProjectName</key>
+	<string>ACCodeSnippetRepository</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>802507896EE86DD6AF806A3AB8E4B78A232062A4</key>
+		<string>https://github.com/langyapojun/ACCodeSnippetRepositoryPlugin.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>ACCodeSnippetRepository.xcodeproj</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>802507896EE86DD6AF806A3AB8E4B78A232062A4</key>
+		<string>../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>https://github.com/langyapojun/ACCodeSnippetRepositoryPlugin.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>802507896EE86DD6AF806A3AB8E4B78A232062A4</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>802507896EE86DD6AF806A3AB8E4B78A232062A4</string>
+			<key>IDESourceControlWCCName</key>
+			<string>ACCodeSnippetRepositoryPlugin</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ACCodeSnippetRepository/ACCodeSnippetRepository-Info.plist
+++ b/ACCodeSnippetRepository/ACCodeSnippetRepository-Info.plist
@@ -30,6 +30,7 @@
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>ACCodeSnippetRepositoryPlugin</string>


### PR DESCRIPTION
check Xcode DVTPlugInCompatibilityUUID command:
defaults read /Applications/Xcode.app/Contents/Info DVTPlugInCompatibilityUUID
and add in *-info.plist's property DVTPlugInCompatibilityUUIDs array
