### PR TITLE
fix bug in date formatting

### DIFF
--- a/ACCodeSnippetRepository/Controllers/ACCodeSnippetRepositoryConfigurationWindowController.m
+++ b/ACCodeSnippetRepository/Controllers/ACCodeSnippetRepositoryConfigurationWindowController.m
@@ -270,7 +270,7 @@ NSString * const ACCodeSnippetRepositoryUpdateRegularlyKey = @"ACCodeSnippetRepo
 - (NSString*)pathForBackupDirectory {
     NSDate *currentDate = [NSDate date];
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"YYMMdd-HHmm"];
+    [dateFormatter setDateFormat:@"yyMMdd-HHmm"];
     return [NSString pathWithComponents:@[self.pathForSnippetDirectory, [NSString stringWithFormat:@"backup-%@", [dateFormatter stringFromDate:currentDate]]]];
 }
 


### PR DESCRIPTION
 see http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns

(this bug is rumored to have brought down Twitter last December)

basically using YY instead of yy means than the last few days in December will be formatted with the wrong year (the following year) since YY looks up the 'week of year'. 
